### PR TITLE
Added code so that we can also support content uri

### DIFF
--- a/src/android/CropPlugin.java
+++ b/src/android/CropPlugin.java
@@ -39,7 +39,13 @@ public class CropPlugin extends CordovaPlugin {
             height = height == 0 ? width : height;
             quality = quality == 0 ? 100 : quality;
 
-            this.inputUri = Uri.parse("file://" + imagePath);
+            if (!imagePath.contains("content:") && !imagePath.contains("file:")) {
+                this.inputUri = Uri.parse("file://" + imagePath);
+            }
+            else
+            {
+                this.inputUri = Uri.parse(imagePath);
+            }
             this.outputUri = Uri.fromFile(new File(getTempDirectoryPath() + "/" + System.currentTimeMillis() + "-cropped.jpg"));
 
             PluginResult pr = new PluginResult(PluginResult.Status.NO_RESULT);


### PR DESCRIPTION
Content URI start with the string "content://" and file uri starts with the scheme "file://". Some phone do not add a scheme, in those cases we add the "file://"  in the else part. For all the other cases the URI will remain as it should be.

Cordova plugin for camera returns a File URI when we select the camera. And in case of the Gallery it returns a Content URI.
